### PR TITLE
Enable uv/pdm install from Git

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "lightningcss"
+dynamic = ["version"]
 description = "Python bindings for lightningcss."
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
The package version is managed in Cargo.toml, not in pyproject.toml. While "pip install" from Git works fine, it doesn't work from uv or pdm. Installation stops with a parse error:

> `pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list

Marking `version` as dynamic seems to be the [official solution](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#version).