### PR TITLE
Add missing type hints for bundle_css

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,19 +52,20 @@ output_css = lightningcss.process_stylesheet(
 )
 ```
 
+The `filename` keyword parameter is only used for displaying error messages from
+the parser. When using `browsers_list`, lightningcss will try to transpile the
+code to be compatible with the specified
+[browserslist target](https://browsersl.ist/).
+
 This package also supports creating a CSS bundle where all `@import` rules are
 resolved into a single stylesheet:
 
 ```py
 bundled_css = lightningcss.bundle_css(
     "main.css",
-    filename = "main.css",
     browsers_list = ["defaults"],
     minify = False,
 )
 ```
 
-All resources referenced via `@import` are resolved relative to the main file. The
-`filename` keyword parameter is only used for displaying error messages from the
-parser. When using `browsers_list`, lightningcss will try to transpile the code
-to be compatible with the specified [browserslist target](https://browsersl.ist/).
+All resources referenced via `@import` are resolved relative to the main file.

--- a/lightningcss.pyi
+++ b/lightningcss.pyi
@@ -12,7 +12,7 @@ def calc_parser_flags(
     deep_selector_combinator: bool = False
 ) -> ParserFlags:
     """
-    Calculates the `parser_flags` argument of `process_stylesheet()`.
+    Calculates the `parser_flags` argument of `process_stylesheet()` and `bundle_css()`.
     """
 
 def process_stylesheet(
@@ -42,7 +42,40 @@ def process_stylesheet(
     :param browsers_list: An optional list of browserslist targets to be used
         to determine automatic prefixing and transpilation. If it is not
         specified, no prefixing/transpilation will occur.
-    :param minify: Is True, the final output will be minified. Otherwise, it
+    :param minify: If True, the final output will be minified. Otherwise, it
         will be pretty-printed.
     :return: A string containing a processed CSS stylesheet.
+    """
+
+def bundle_css(
+    path: str,
+    /,
+    error_recovery: bool = False,
+    parser_flags: ParserFlags = ParserFlags(0),
+    unused_symbols: set[str] | None = None,
+    browsers_list: list[str] | None = None,
+    minify: bool = True
+) -> str:
+    """
+    Processes the supplied CSS stylesheet file and returns the bundle as a string.
+
+    Resolves all `@import` rules to create a single CSS bundle. The resources
+    referenced via `@import` are resolved relative to the main file.
+
+    :param path: A string containing the path of the stylesheet file to process.
+    :param error_recovery: Whether or not to omit broken CSS rather than
+        producing a parse error. Enable with caution!
+    :param parser_flags: An optional flag created by `calc_parser_flags()`.
+        See that function for more details.
+    :param unused_symbols: An optional set of known unused symbols, like
+        classnames, ids, or keyframe names, to be removed from the output.
+        Note that symbols should be specified in bare form, i.e.
+        `unused_symbols={'a', 'b'}`, not `unused_symbols={'.a', '#b'}`, and
+        will remove both ids and classes if they share a name. Use with caution!
+    :param browsers_list: An optional list of browserslist targets to be used
+        to determine automatic prefixing and transpilation. If it is not
+        specified, no prefixing/transpilation will occur.
+    :param minify: If True, the final output will be minified. Otherwise, it
+        will be pretty-printed.
+    :return: A string containing the CSS bundle.
     """


### PR DESCRIPTION
Add the missing type hints for the bundle_css function.

Fixes #11